### PR TITLE
ci: stop ci running on gh-pages branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
           command: |
             git config --global user.email "circleci-richtextview@users.noreply.github.com"
             git config --global user.name "CircleCI RichTextView"
-            USE_SSH=true yarn publish-gh-pages
+            CUSTOM_COMMIT_MESSAGE="[skip ci]" USE_SSH=true yarn publish-gh-pages
 
 workflows:
   version: 2


### PR DESCRIPTION
## Description
Fixes this:
<img width="616" alt="screen shot 2018-12-23 at 11 20 51 am" src="https://user-images.githubusercontent.com/3534236/50380527-d6d1fd00-06a4-11e9-950f-fdd7945bc53e.png">
