### PR TITLE
fix: Drop iOS 9 Support

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 # ignore all warnings from all pods
 inhibit_all_warnings!
@@ -11,4 +11,12 @@ target 'RichTextView-Example' do
   pod 'RichTextView', :path => '../'
   pod 'SwiftLint'
 
+end
+
+post_install do |installer|
+  installer.pods_project.build_configurations.each do |config|
+    config.build_settings['CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED'] = 'YES'
+  end
+  installer.pods_project.root_object.known_regions = ["Base", "en"]
+  installer.pods_project.root_object.development_region = "en"
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Down (0.6.1)
   - iosMath (0.9.4)
-  - RichTextView (1.1.2):
+  - RichTextView (2.0.0):
     - Down
     - iosMath
     - SnapKit
@@ -26,10 +26,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Down: 8d305822b0a69c393cddaf1d21d2bb2e0b34d544
   iosMath: f7a6cbadf9d836d2149c2a84c435b1effc244cba
-  RichTextView: 1ee755ae668e81a0bf74f159e21efb4c06309ae1
+  RichTextView: 8f0b65be8f8635147cfacd6775a253f5c15cd062
   SnapKit: fe8a619752f3f27075cc9a90244d75c6c3f27e2a
   SwiftLint: 7f5f7de0da74a649b16616cb5246ae323489656e
 
-PODFILE CHECKSUM: b0315224e857e65e7ac6b79fc4df5528c573d32a
+PODFILE CHECKSUM: 7ed278778742c6fba1a76cb63542d5cc16be9fb8
 
 COCOAPODS: 1.6.1

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Down (0.6.1)
   - iosMath (0.9.4)
-  - RichTextView (1.1.1):
+  - RichTextView (1.1.2):
     - Down
     - iosMath
     - SnapKit
@@ -26,10 +26,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Down: 8d305822b0a69c393cddaf1d21d2bb2e0b34d544
   iosMath: f7a6cbadf9d836d2149c2a84c435b1effc244cba
-  RichTextView: b862700d61d1af07a7a2ec73b733adcb0211eb31
+  RichTextView: 1ee755ae668e81a0bf74f159e21efb4c06309ae1
   SnapKit: fe8a619752f3f27075cc9a90244d75c6c3f27e2a
   SwiftLint: 7f5f7de0da74a649b16616cb5246ae323489656e
 
-PODFILE CHECKSUM: c8bc7e78a2a8b5476de96876e3abe7f0946be5d6
+PODFILE CHECKSUM: b0315224e857e65e7ac6b79fc4df5528c573d32a
 
 COCOAPODS: 1.6.1

--- a/Example/RichTextView-Example.xcodeproj/project.pbxproj
+++ b/Example/RichTextView-Example.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 				TargetAttributes = {
 					781489192195323700DED7A1 = {
 						CreatedOnToolsVersion = 10.0;
+						LastSwiftMigration = 1020;
 					};
 				};
 			};
@@ -390,7 +391,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tophat.RichTextView-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -409,7 +410,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tophat.RichTextView-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Podfile
+++ b/Podfile
@@ -33,6 +33,7 @@ end
 post_install do |installer|
     installer.pods_project.targets.each do |target|
         target.build_configurations.each do |config|
+            config.build_settings['CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED'] = 'YES'
             # This works around a unit test issue introduced in Xcode 10.
             # We only apply it to the Debug configuration to avoid bloating the app size
             if config.name == "Debug" && defined?(target.product_type) && target.product_type == "com.apple.product-type.framework"
@@ -41,4 +42,6 @@ post_install do |installer|
             config.build_settings['SWIFT_VERSION'] = '5.0'
         end
     end
+    installer.pods_project.root_object.known_regions = ["Base", "en"]
+    installer.pods_project.root_object.development_region = "en"
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -13,7 +13,7 @@ PODS:
     - iOSSnapshotTestCase (~> 4.0)
     - Nimble (~> 7.0)
   - Quick (2.0.0)
-  - SnapKit (4.2.0)
+  - SnapKit (5.0.0)
   - SwiftLint (0.29.1)
 
 DEPENDENCIES:
@@ -51,9 +51,9 @@ SPEC CHECKSUMS:
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   Nimble-Snapshots: 79394f8d0aea3df54bd5ff78ee9dff05a523a09c
   Quick: ce1276c7c27ba2da3cb2fd0cde053c3648b3b22d
-  SnapKit: fe8a619752f3f27075cc9a90244d75c6c3f27e2a
+  SnapKit: fd22d10eb9aff484d79a8724eab922c1ddf89bcf
   SwiftLint: 6772320e40b52049053a518c17db9b0634a0b45a
 
-PODFILE CHECKSUM: ea3f61bdf98d94774ed1901506f9c4bb22a14950
+PODFILE CHECKSUM: fd6952a9b41a9a41bb7e6fb036901d60f1134d46
 
 COCOAPODS: 1.6.1

--- a/RichTextView.podspec
+++ b/RichTextView.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'RichTextView'
-  s.version          = '1.1.1'
+  s.version          = '1.1.2'
   s.summary          = 'iOS Text View that Properly Displays LaTeX, HTML, Markdown, and YouTube/Vimeo Links.'
   s.description      = <<-DESC
 This is an iOS UIView that Properly Displays LaTeX, HTML, Markdown, and YouTube/Vimeo Links. Simply feed in an input
@@ -24,7 +24,7 @@ string with the relevant rich text surrounded by the appropriate tags and it wil
   s.author           = { 'Top Hat' => 'tophat' }
   s.source           = { :git => 'https://github.com/tophat/RichTextView.git', :tag => s.version.to_s }
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '10.0'
   s.source_files = 'Source/*.swift', 'Source/Text Parsing/*.swift', 'Source/Constants/*.swift', 'Source/Extensions/*.swift', 'Source/View Generators/*.swift', 'Source/Delegates/*.swift'
   s.dependency 'Down'
   s.dependency 'iosMath'

--- a/RichTextView.podspec
+++ b/RichTextView.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'RichTextView'
-  s.version          = '1.1.2'
+  s.version          = '2.0.0'
   s.summary          = 'iOS Text View that Properly Displays LaTeX, HTML, Markdown, and YouTube/Vimeo Links.'
   s.description      = <<-DESC
 This is an iOS UIView that Properly Displays LaTeX, HTML, Markdown, and YouTube/Vimeo Links. Simply feed in an input

--- a/RichTextView.xcodeproj/project.pbxproj
+++ b/RichTextView.xcodeproj/project.pbxproj
@@ -649,7 +649,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -707,7 +707,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -732,6 +732,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -759,6 +760,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -779,6 +781,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 8N4V63T666;
 				INFOPLIST_FILE = UnitTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -798,6 +801,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 8N4V63T666;
 				INFOPLIST_FILE = UnitTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -817,6 +821,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 8N4V63T666;
 				INFOPLIST_FILE = UITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -837,6 +842,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 8N4V63T666;
 				INFOPLIST_FILE = UITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/RichTextView.xcodeproj/project.pbxproj
+++ b/RichTextView.xcodeproj/project.pbxproj
@@ -373,6 +373,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 781488DF2194E6B600DED7A1;
 			productRefGroup = 781488EA2194E6B600DED7A1 /* Products */;


### PR DESCRIPTION
## Description
This PR is to drop support of iOS 9 so RichTextView is compatible with the latest SnapKit.

## DevQA
- Run `pod install`
- Test `RichTextView` to ensure that it passes (unit and UI tests)
- Navigate to the `Example` project in the root `Example` folder and run the app
- Ensure that everything in the `Example` app looks visually correct
