### PR TITLE
fix: Enable updating of background color

### DIFF
--- a/Source/RichTextView.swift
+++ b/Source/RichTextView.swift
@@ -101,6 +101,7 @@ public class RichTextView: UIView {
                     make.bottom.equalTo(self)
                 }
             }
+            subview.backgroundColor = UIColor.clear
         }
     }
 


### PR DESCRIPTION
## Description
* Added ability to set the background colour of `RichTextView` via:
```
let richTextView = RichTextView()
richTextView.backgroundColor = .red
```
Fixes #96 

## DevQA
In the Example project in the `InputOutputModuleView` try setting the background color of the RichTextView as above, you will see an update in the simulator with the new background color after you re-compile and re-run.

### DevQA Prep
- Run `pod install`
- Test `RichTextView` to ensure that it passes (unit and UI tests)
- Navigate to the `Example` project in the root `Example` folder and run the app
- Ensure that everything in the `Example` app looks visually correct
