### PR TITLE
fix: Update RichTextParser.swift to also consume interactive element attributes. 

### DIFF
--- a/Source/Text Parsing/RichTextParser.swift
+++ b/Source/Text Parsing/RichTextParser.swift
@@ -147,7 +147,9 @@ class RichTextParser {
         let interactiveElementTagName = ParserConstants.interactiveElementTagName
         let interactiveElementID = input.string.getSubstring(inBetween: "[\(interactiveElementTagName) id=", and: "]") ?? input.string
         let interactiveElementText = input.string.getSubstring(inBetween: "]", and: "[/\(interactiveElementTagName)]") ?? input.string
-        let attributes: [NSAttributedString.Key: Any] = [.customLink: interactiveElementID, .foregroundColor: self.interactiveTextColor, .font: self.font].merging(input.attributes(at: 0, effectiveRange: nil)) { (current, _) in current }
+        let attributes: [NSAttributedString.Key: Any] = [.customLink: interactiveElementID,
+                                                         .foregroundColor: self.interactiveTextColor,
+                                                         .font: self.font].merging(input.attributes(at: 0, effectiveRange: nil)) { (current, _) in current }
         let mutableAttributedInput = NSMutableAttributedString(string: " " + interactiveElementText + " ", attributes: attributes)
         return mutableAttributedInput
     }

--- a/Source/Text Parsing/RichTextParser.swift
+++ b/Source/Text Parsing/RichTextParser.swift
@@ -147,9 +147,11 @@ class RichTextParser {
         let interactiveElementTagName = ParserConstants.interactiveElementTagName
         let interactiveElementID = input.string.getSubstring(inBetween: "[\(interactiveElementTagName) id=", and: "]") ?? input.string
         let interactiveElementText = input.string.getSubstring(inBetween: "]", and: "[/\(interactiveElementTagName)]") ?? input.string
-        let attributes: [NSAttributedString.Key: Any] = [.customLink: interactiveElementID,
-                                                         .foregroundColor: self.interactiveTextColor,
-                                                         .font: self.font].merging(input.attributes(at: 0, effectiveRange: nil)) { (current, _) in current }
+        let attributes: [NSAttributedString.Key: Any] = [
+            .customLink: interactiveElementID,
+            .foregroundColor: self.interactiveTextColor,
+            .font: self.font
+        ].merging(input.attributes(at: 0, effectiveRange: nil)) { (current, _) in current }
         let mutableAttributedInput = NSMutableAttributedString(string: " " + interactiveElementText + " ", attributes: attributes)
         return mutableAttributedInput
     }

--- a/Source/Text Parsing/RichTextParser.swift
+++ b/Source/Text Parsing/RichTextParser.swift
@@ -116,7 +116,7 @@ class RichTextParser {
         var parsingErrors: [ParsingError]?
         for attributedString in attributedStringComponents {
             if self.isTextInteractiveElement(attributedString.string) {
-                output.append(self.extractInteractiveElement(from: attributedString.string))
+                output.append(self.extractInteractiveElement(from: attributedString))
             } else if self.isTextLatex(attributedString.string) {
                 if let attributedLatexString = self.extractLatex(from: attributedString.string) {
                     output.append(attributedLatexString)
@@ -143,11 +143,11 @@ class RichTextParser {
         )
     }
 
-    func extractInteractiveElement(from input: String) -> NSMutableAttributedString {
+    func extractInteractiveElement(from input: NSAttributedString) -> NSMutableAttributedString {
         let interactiveElementTagName = ParserConstants.interactiveElementTagName
-        let interactiveElementID = input.getSubstring(inBetween: "[\(interactiveElementTagName) id=", and: "]") ?? input
-        let interactiveElementText = input.getSubstring(inBetween: "]", and: "[/\(interactiveElementTagName)]") ?? input
-        let attributes: [NSAttributedString.Key: Any] = [.customLink: interactiveElementID, .foregroundColor: self.interactiveTextColor, .font: self.font]
+        let interactiveElementID = input.string.getSubstring(inBetween: "[\(interactiveElementTagName) id=", and: "]") ?? input.string
+        let interactiveElementText = input.string.getSubstring(inBetween: "]", and: "[/\(interactiveElementTagName)]") ?? input.string
+        let attributes: [NSAttributedString.Key: Any] = [.customLink: interactiveElementID, .foregroundColor: self.interactiveTextColor, .font: self.font].merging(input.attributes(at: 0, effectiveRange: nil)) { (current, _) in current }
         let mutableAttributedInput = NSMutableAttributedString(string: " " + interactiveElementText + " ", attributes: attributes)
         return mutableAttributedInput
     }

--- a/UnitTests/Text Parsing/RichTextParserSpec.swift
+++ b/UnitTests/Text Parsing/RichTextParserSpec.swift
@@ -38,7 +38,7 @@ class RichTextParserSpec: QuickSpec {
             }
             context("Interactive Element") {
                 it("succesfully returns an NSAttributedString with the custom link property from a basic interactive element") {
-                    let output = self.richTextParser.extractInteractiveElement(from: MarkDownText.basicInteractiveElement)
+                    let output = self.richTextParser.extractInteractiveElement(from: NSAttributedString(string: MarkDownText.basicInteractiveElement))
                     let attributes: [NSAttributedString.Key: Any] = [
                         .customLink: "123",
                         .foregroundColor: UIColor.blue,
@@ -48,7 +48,7 @@ class RichTextParserSpec: QuickSpec {
                     expect(output).to(equal(expectedAttributedString))
                 }
                 it("succesfully returns an NSAttributedString with the custom link property from a complex interactive element") {
-                    let output = self.richTextParser.extractInteractiveElement(from: MarkDownText.complexInteractiveElement)
+                    let output = self.richTextParser.extractInteractiveElement(from: NSAttributedString(string: MarkDownText.complexInteractiveElement))
                     let attributes: [NSAttributedString.Key: Any] = [
                         .customLink: "123",
                         .foregroundColor: UIColor.blue,


### PR DESCRIPTION
## Description
 - Updated `extractInteractiveElement` function to also take in the interactive element's attributes. 


## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Run `pod install`
- Test `RichTextView` to ensure that it passes (unit and UI tests)
- Navigate to the `Example` project in the root `Example` folder and run the app
- Ensure that everything in the `Example` app looks visually correct


### DevQA Steps
- Navigate to the example project view controller and add this to the private enums Views.subviews:
`InputOutputModuleView(text: """
<sup>[interactive-element id=183d8b0a-db9b-4eda-a0cf-b55bf0a63323]3[/interactive-element]</sup>
""")`
- Run the example project and see a super script interactive element.

### Comments
<!-- Any other comments you want to include for reviewers. -->


