### PR TITLE
fix: Update RichTextParser.swift to have regex for interactive elements not be greedy. 

### DIFF
--- a/Source/Text Parsing/RichTextParser.swift
+++ b/Source/Text Parsing/RichTextParser.swift
@@ -14,7 +14,7 @@ class RichTextParser {
         static let mathTagName = "math"
         static let interactiveElementTagName = "interactive-element"
         static let latexRegex = "\\[\(ParserConstants.mathTagName)\\](.*?)\\[\\/\(ParserConstants.mathTagName)\\]"
-        static let interactiveElementRegex = "\\[\(ParserConstants.interactiveElementTagName)\\sid=.+\\].*\\[\\/\(ParserConstants.interactiveElementTagName)\\]"
+        static let interactiveElementRegex = "\\[\(ParserConstants.interactiveElementTagName)\\sid=.+?\\].*?\\[\\/\(ParserConstants.interactiveElementTagName)\\]"
         typealias RichTextWithErrors = (output: NSAttributedString, errors: [ParsingError]?)
     }
 

--- a/Source/Text Parsing/RichTextParser.swift
+++ b/Source/Text Parsing/RichTextParser.swift
@@ -14,7 +14,9 @@ class RichTextParser {
         static let mathTagName = "math"
         static let interactiveElementTagName = "interactive-element"
         static let latexRegex = "\\[\(ParserConstants.mathTagName)\\](.*?)\\[\\/\(ParserConstants.mathTagName)\\]"
-        static let interactiveElementRegex = "\\[\(ParserConstants.interactiveElementTagName)\\sid=.+?\\].*?\\[\\/\(ParserConstants.interactiveElementTagName)\\]"
+        static let interactiveElementRegex = """
+            \\[\(ParserConstants.interactiveElementTagName)\\sid=.+?\\].*?\\[\\/\(ParserConstants.interactiveElementTagName)\\]
+        """
         typealias RichTextWithErrors = (output: NSAttributedString, errors: [ParsingError]?)
     }
 

--- a/UnitTests/Extensions/StringExtensionSpec.swift
+++ b/UnitTests/Extensions/StringExtensionSpec.swift
@@ -99,6 +99,18 @@ class StringExtensionSpec: QuickSpec {
                     expect(ranges[1].lowerBound.utf16Offset(in: initialString)).to(equal(38))
                     expect(ranges[1].upperBound.utf16Offset(in: initialString)).to(equal(60))
                 }
+                it("returns the ranges of given text with multiple interactive elements.") {
+                    let initialString = """
+                        [interactive-element id=1]Some interactive element text[/interactive-element] different text
+                        [interactive-element id=1]more interactive element text[/interactive-element]
+                    """
+                    let ranges = initialString.ranges(of: "\\[interactive-element\\sid=.+?\\].*?\\[\\/interactive-element\\]", options: .regularExpression)
+                    expect(ranges.count).to(equal(2))
+                    expect(ranges[0].lowerBound.utf16Offset(in: initialString)).to(equal(4))
+                    expect(ranges[0].upperBound.utf16Offset(in: initialString)).to(equal(81))
+                    expect(ranges[1].lowerBound.utf16Offset(in: initialString)).to(equal(101))
+                    expect(ranges[1].upperBound.utf16Offset(in: initialString)).to(equal(178))
+                }
             }
         }
     }


### PR DESCRIPTION
## Description
Update RichTextParser.swift to have regex for interactive elements not be greedy. 

## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Run `pod install`
- Test `RichTextView` to ensure that it passes (unit and UI tests)
- Navigate to the `Example` project in the root `Example` folder and run the app
- Ensure that everything in the `Example` app looks visually correct


### DevQA Steps
- Navigate to example project VC and change the private enums to `InputOutputModuleView(text: """ [interactive-element id=1]Some interactive element text[/interactive-element] different text[interactive-element id=1]more interactive element text[/interactive-element] """)`

Run the example project and see a that all interactive elements are shown.

### Comments
<!-- Any other comments you want to include for reviewers. -->


