### PR TITLE
fix: Remove leading space in interactive element regex

### DIFF
--- a/Source/Text Parsing/RichTextParser.swift
+++ b/Source/Text Parsing/RichTextParser.swift
@@ -15,7 +15,7 @@ class RichTextParser {
         static let interactiveElementTagName = "interactive-element"
         static let latexRegex = "\\[\(ParserConstants.mathTagName)\\](.*?)\\[\\/\(ParserConstants.mathTagName)\\]"
         static let interactiveElementRegex = """
-            \\[\(ParserConstants.interactiveElementTagName)\\sid=.+?\\].*?\\[\\/\(ParserConstants.interactiveElementTagName)\\]
+        \\[\(ParserConstants.interactiveElementTagName)\\sid=.+?\\].*?\\[\\/\(ParserConstants.interactiveElementTagName)\\]
         """
         typealias RichTextWithErrors = (output: NSAttributedString, errors: [ParsingError]?)
     }


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->


## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Run `pod install`
- Test `RichTextView` to ensure that it passes (unit and UI tests)
- Navigate to the `Example` project in the root `Example` folder and run the app
- Ensure that everything in the `Example` app looks visually correct


### DevQA Steps
- Navigate to example project VC and change the private enums to InputOutputModuleView(text: """ [interactive-element id=1]Some interactive element text[/interactive-element] different text[interactive-element id=1]more interactive element text[/interactive-element] """)



### Comments
<!-- Any other comments you want to include for reviewers. -->


