### PR TITLE
fix: Add hard breaks to Markdown

### DIFF
--- a/Source/Text Parsing/RichTextParser.swift
+++ b/Source/Text Parsing/RichTextParser.swift
@@ -120,7 +120,7 @@ class RichTextParser {
         let relevantString = entireAttributedString.string[
             max(range.lowerBound, 0)..<min(range.upperBound, entireAttributedString.string.count)
         ]
-        guard let attributedInput = try? Down(markdownString: relevantString).toAttributedString(.unsafe, stylesheet: nil) else {
+        guard let attributedInput = try? Down(markdownString: relevantString).toAttributedString([.unsafe, .hardBreaks], stylesheet: nil) else {
             return (nil, ParsingError.attributedTextGeneration(text: relevantString))
         }
         let mutableAttributedInput = NSMutableAttributedString(attributedString: attributedInput)


### PR DESCRIPTION
## Description
In order for Markdown tables to look nice we need to add hard breaks as an option in the markdown parser

## DevQA

### DevQA Prep
- Run `pod install`
- Test `RichTextView` to ensure that it passes (unit and UI tests)
- Navigate to the `Example` project in the root `Example` folder and run the app
- Ensure that everything in the `Example` app looks visually correct

### DevQA Steps
Try out the following string before/after - there should be line breaks at least in the table even if it doesn't render properly
```
        | Substance | [math]\\underline{S^{0} (\\frac{J}{mole K}}][/math] |
        | --------- | --------------|
        | [math]Na_2CO_3[/math] | 61.1 |
        | [math]HCl(aq)[/math] | 56.5 |
        | [math]NaCl(aq)[/math] | 115.5 |
        | [math]H_2O[/math] | 70.0 |
        | [math]CO_2(g)[/math] | 213.8 |
```
