### PR TITLE
fix: fixed StringExtension.split method in order to avoid out of bounds crash

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -31,14 +31,13 @@ DEPENDENCIES:
   - SwiftLint
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - Down
+    - DTCoreText
+    - DTFoundation
     - iosMath
     - SnapKit
     - SwiftLint
-  trunk:
-    - DTCoreText
-    - DTFoundation
 
 EXTERNAL SOURCES:
   RichTextView:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -44,17 +44,16 @@ DEPENDENCIES:
   - SwiftLint
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - Down
+    - DTCoreText
+    - DTFoundation
     - iOSSnapshotTestCase
     - Nimble
     - Nimble-Snapshots
     - Quick
     - SnapKit
     - SwiftLint
-  trunk:
-    - DTCoreText
-    - DTFoundation
 
 EXTERNAL SOURCES:
   iosMath:

--- a/Source/Extensions/StringExtension.swift
+++ b/Source/Extensions/StringExtension.swift
@@ -62,6 +62,9 @@ extension String {
     func split(atPositions positions: [Index]) -> [String] {
         var substrings = [String]()
         var start = 0
+        var positions = positions
+        positions.sort()
+        positions = positions.filter { return $0 > self.startIndex && $0 < self.endIndex }
         while start < positions.count {
             let substring: String = {
                 let startIndex = positions[start]
@@ -79,6 +82,9 @@ extension String {
             if !substring.isEmpty {
                 substrings.append(substring)
             }
+        }
+        if substrings.isEmpty {
+            return [self]
         }
         return substrings
     }

--- a/UnitTests/Extensions/StringExtensionSpec.swift
+++ b/UnitTests/Extensions/StringExtensionSpec.swift
@@ -79,6 +79,24 @@ class StringExtensionSpec: QuickSpec {
                     expect(splitStrings[2]).to(equal("be "))
                     expect(splitStrings[3]).to(equal("split"))
                 }
+                it("splits the string on the first and last index") {
+                    let regularString = "You know nothing, Jon Snow"
+                    let positions: [String.Index] = [0, 26].compactMap { return String.Index(utf16Offset: $0, in: regularString) }
+                    let substrings = regularString.split(atPositions: positions)
+                    expect(substrings).to(equal([regularString]))
+                }
+                it("splits the string on out of bounds indices") {
+                    let regularString = "You know nothing, Jon Snow"
+                    let positions: [String.Index] = [-1, 100].compactMap { return String.Index(utf16Offset: $0, in: regularString) }
+                    let substrings = regularString.split(atPositions: positions)
+                    expect(substrings).to(equal([regularString]))
+                }
+                it("splits the string when the input positions are out of order") {
+                    let regularString = "You know nothing, Jon Snow"
+                    let positions: [String.Index] = [5, 9, 2, 20, 7].compactMap { return String.Index(utf16Offset: $0, in: regularString) }
+                    let substrings = regularString.split(atPositions: positions)
+                    expect(substrings).to(equal(["Yo", "u k", "no", "w ", "nothing, Jo", "n Snow"]))
+                }
             }
             context("Ranges") {
                 it("returns the ranges of given text") {


### PR DESCRIPTION
## Description
- fixed StringExtension.split method in order to avoid out of bounds crash

