### PR TITLE
fix: update to extend uitextview

### DIFF
--- a/Source/Delegates/RichTextViewDelegate.swift
+++ b/Source/Delegates/RichTextViewDelegate.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2019 Top Hat. All rights reserved.
 //
 
-public protocol RichTextViewDelegate: UITextViewDelegate {
+@objc public protocol RichTextViewDelegate: UITextViewDelegate {
+    func loadHiglightMenuItemTapped()
     func didTapCustomLink(withID linkID: String)
+    @objc optional func canPerformRichTextViewAction(_ action: Selector, withSender sender: Any?) -> Bool
 }

--- a/Source/View Generators/UITextViewGenerator.swift
+++ b/Source/View Generators/UITextViewGenerator.swift
@@ -6,6 +6,22 @@
 //  Copyright © 2018 Top Hat. All rights reserved.
 //
 
+extension UITextView {
+    override open func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if let richTextViewDelegate = self.delegate as? RichTextViewDelegate,
+            let canPerformAction = richTextViewDelegate.canPerformRichTextViewAction?(action, withSender: sender) {
+            return canPerformAction
+        }
+        return super.canPerformAction(action, withSender: sender)
+    }
+
+    @objc func loadHighlightMenuItemTapped(_ sender: Any) {
+        if let richTextViewDelegate = self.delegate as? RichTextViewDelegate {
+            richTextViewDelegate.loadHiglightMenuItemTapped()
+        }
+    }
+}
+
 class UITextViewGenerator {
 
     // MARK: - Init

--- a/UnitTests/View Generators/UITextViewGeneratorSpec.swift
+++ b/UnitTests/View Generators/UITextViewGeneratorSpec.swift
@@ -18,6 +18,7 @@ class UITextViewGeneratorSpec: QuickSpec {
                 it("creates a label using an NSAttributedString") {
                     let attributedString = NSAttributedString(string: "some text")
                     class TextViewDelegate: NSObject, RichTextViewDelegate {
+                        func loadHiglightMenuItemTapped() {}
                         func didTapCustomLink(withID linkID: String) {}
                     }
                     let delegate = TextViewDelegate()


### PR DESCRIPTION
## Description
added optional method to protocol to use delegates canPerformAction method if it exists. 


## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Run `pod install`
- Test `RichTextView` to ensure that it passes (unit and UI tests)
- Navigate to the `Example` project in the root `Example` folder and run the app
- Ensure that everything in the `Example` app looks visually correct


### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->



### Comments
<!-- Any other comments you want to include for reviewers. -->


