### PR TITLE
chore: remove greenkeeper config

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -1,9 +1,0 @@
-{
-  "groups": {
-    "default": {
-      "packages": [
-        "website/package.json"
-      ]
-    }
-  }
-}


### PR DESCRIPTION
[GreenKeeper will be stopping operation in early June 2020](https://greenkeeper.io/), so we are migrating to GH's Dependabot for automated dependency management. This PR removes Greenkeeper's config, and an init PR for Dependabot is on the way.

Dependabot will only be enabled for the `website` directory since those updates won't affect RTV.