### PR TITLE
fix: disable accessibility if input string is empty

### DIFF
--- a/Source/View Generators/UITextViewGenerator.swift
+++ b/Source/View Generators/UITextViewGenerator.swift
@@ -46,7 +46,7 @@ class UITextViewGenerator {
         mutableInput.replaceColor(with: textColor)
         textView.attributedText = mutableInput
         textView.accessibilityValue = input.string
-        textView.isAccessibilityElement = true
+        textView.isAccessibilityElement = !input.string.isEmpty
         textView.isSelectable = isSelectable
         textView.isEditable = isEditable
         textView.isScrollEnabled = false

--- a/Source/View Generators/UITextViewGenerator.swift
+++ b/Source/View Generators/UITextViewGenerator.swift
@@ -46,6 +46,7 @@ class UITextViewGenerator {
         mutableInput.replaceColor(with: textColor)
         textView.attributedText = mutableInput
         textView.accessibilityValue = input.string
+        //disable accesibility if input is emtry string
         textView.isAccessibilityElement = !input.string.isEmpty
         textView.isSelectable = isSelectable
         textView.isEditable = isEditable


### PR DESCRIPTION
## Description
Disable accessibility for UITextView  if the input string is empty.


## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Run `pod install`
- Test `RichTextView` to ensure that it passes (unit and UI tests)
- Navigate to the `Example` project in the root `Example` folder and run the app
- Ensure that everything in the `Example` app looks visually correct


### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->



### Comments
<!-- Any other comments you want to include for reviewers. -->


