### PR TITLE
fix: Remove common editor tags before converting to HTML

### DIFF
--- a/Source/Text Parsing/RichTextParser.swift
+++ b/Source/Text Parsing/RichTextParser.swift
@@ -205,7 +205,7 @@ class RichTextParser {
     private func getRichTextWithHTMLAndMarkdownHandled(fromString mutableAttributedString: NSMutableAttributedString) -> ParserConstants.RichTextWithErrors {
         let inputString = mutableAttributedString.string
         let inputStringWithoutBreakingSpaces = inputString.replaceTrailingWhiteSpaceWithNonBreakingSpace().replaceLeadingWhiteSpaceWithNonBreakingSpace()
-        let inputStringWithoutCommonEditorTags = removeCommonEditorTags(from: inputStringWithoutBreakingSpaces)
+        let inputStringWithoutCommonEditorTags = self.removeCommonEditorTags(from: inputStringWithoutBreakingSpaces)
         guard let inputAsHTMLString = try? Down(markdownString: inputStringWithoutCommonEditorTags).toHTML([.unsafe, .hardBreaks]),
             let inputAsHTMLWithZeroWidthSpaceRemoved = inputAsHTMLString.replaceAppropiateZeroWidthSpaces(),
             let htmlData = inputAsHTMLWithZeroWidthSpaceRemoved.data(using: .utf8) else {

--- a/Source/Text Parsing/RichTextParser.swift
+++ b/Source/Text Parsing/RichTextParser.swift
@@ -205,7 +205,8 @@ class RichTextParser {
     private func getRichTextWithHTMLAndMarkdownHandled(fromString mutableAttributedString: NSMutableAttributedString) -> ParserConstants.RichTextWithErrors {
         let inputString = mutableAttributedString.string
         let inputStringWithoutBreakingSpaces = inputString.replaceTrailingWhiteSpaceWithNonBreakingSpace().replaceLeadingWhiteSpaceWithNonBreakingSpace()
-        guard let inputAsHTMLString = try? Down(markdownString: inputStringWithoutBreakingSpaces).toHTML([.unsafe, .hardBreaks]),
+        let inputStringWithoutCommonEditorTags = removeCommonEditorTags(from: inputStringWithoutBreakingSpaces)
+        guard let inputAsHTMLString = try? Down(markdownString: inputStringWithoutCommonEditorTags).toHTML([.unsafe, .hardBreaks]),
             let inputAsHTMLWithZeroWidthSpaceRemoved = inputAsHTMLString.replaceAppropiateZeroWidthSpaces(),
             let htmlData = inputAsHTMLWithZeroWidthSpaceRemoved.data(using: .utf8) else {
                 return (mutableAttributedString.trimmingTrailingNewlinesAndWhitespaces(), [ParsingError.attributedTextGeneration(text: inputString)])
@@ -254,6 +255,10 @@ class RichTextParser {
 
     private func stripCodeTagsIfNecessary(from input: String) -> String {
         return input.replacingOccurrences(of: "[code]", with: "`").replacingOccurrences(of: "[/code]", with: "`")
+    }
+    
+    private func removeCommonEditorTags(from input: String) -> String {
+        return input.replacingOccurrences(of: "<p id=\"\">", with: "").replacingOccurrences(of: "</p>", with: "")
     }
 
     // MARK: - String Helpers


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
https://tophat.atlassian.net/browse/IOS-8619

Remove common editor tags so that markdown can be rendered within HTML tags.

Still Unknown:
- Unable to render block quotes (Markdown indents) with web FF on


## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Run `pod install`
- Test `RichTextView` to ensure that it passes (unit and UI tests)
- Navigate to the `Example` project in the root `Example` folder and run the app
- Ensure that everything in the `Example` app looks visually correct


### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->

Ask Kushal if you need some examples with HTML embedded with Markdown



### Comments
<!-- Any other comments you want to include for reviewers. -->


