### PR TITLE
fix: Unescape HTML entities after converting from Markdown

### DIFF
--- a/Source/Text Parsing/RichTextParser.swift
+++ b/Source/Text Parsing/RichTextParser.swift
@@ -208,7 +208,7 @@ class RichTextParser {
         let inputStringWithoutCommonEditorTags = self.removeCommonEditorTags(from: inputStringWithoutBreakingSpaces)
         guard let inputAsHTMLString = try? Down(markdownString: inputStringWithoutCommonEditorTags).toHTML([.unsafe, .hardBreaks]),
             let inputAsHTMLWithZeroWidthSpaceRemoved = inputAsHTMLString.replaceAppropiateZeroWidthSpaces(),
-            let htmlData = inputAsHTMLWithZeroWidthSpaceRemoved.data(using: .utf8) else {
+            let htmlData = unescapeHTML(from: inputAsHTMLWithZeroWidthSpaceRemoved).data(using: .utf8) else {
                 return (mutableAttributedString.trimmingTrailingNewlinesAndWhitespaces(), [ParsingError.attributedTextGeneration(text: inputString)])
         }
         let parsedAttributedString = self.getParsedHTMLAttributedString(fromData: htmlData)
@@ -259,6 +259,15 @@ class RichTextParser {
     
     private func removeCommonEditorTags(from input: String) -> String {
         return input.replacingOccurrences(of: "<p id=\"\">", with: "").replacingOccurrences(of: "</p>", with: "")
+    }
+    
+    private func unescapeHTML(from input: String) -> String {
+        return input.replacingOccurrences(of: "&amp;", with: "&")
+            .replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&gt;", with: ">")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&nbsp;", with: " ")
     }
 
     // MARK: - String Helpers

--- a/Source/Text Parsing/RichTextParser.swift
+++ b/Source/Text Parsing/RichTextParser.swift
@@ -256,17 +256,17 @@ class RichTextParser {
     private func stripCodeTagsIfNecessary(from input: String) -> String {
         return input.replacingOccurrences(of: "[code]", with: "`").replacingOccurrences(of: "[/code]", with: "`")
     }
-    
+
     private func removeCommonEditorTags(from input: String) -> String {
         return input.replacingOccurrences(of: "<p id=\"\">", with: "").replacingOccurrences(of: "</p>", with: "")
     }
-    
+
     private func unescapeHTML(from input: String) -> String {
         return input.replacingOccurrences(of: "&amp;", with: "&")
             .replacingOccurrences(of: "&lt;", with: "<")
             .replacingOccurrences(of: "&gt;", with: ">")
             .replacingOccurrences(of: "&quot;", with: "\"")
-            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&#39;", with: "'")
             .replacingOccurrences(of: "&nbsp;", with: " ")
     }
 


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
https://tophat.atlassian.net/browse/IOS-8669

## DevQA

### Before
![Screen Shot 2021-05-12 at 12 05 05 PM](https://user-images.githubusercontent.com/15823571/118010987-8616d980-b31d-11eb-8610-a86bdbf04f41.png)

### After
![Screen Shot 2021-05-12 at 12 04 27 PM](https://user-images.githubusercontent.com/15823571/118011002-8adb8d80-b31d-11eb-82b2-5d13c85db4ad.png)


### DevQA Prep
<!-- Delete items that do not apply. -->
- Run `pod install`
- Test `RichTextView` to ensure that it passes (unit and UI tests)
- Navigate to the `Example` project in the root `Example` folder and run the app
- Ensure that everything in the `Example` app looks visually correct


### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->



### Comments
<!-- Any other comments you want to include for reviewers. -->


