### PR TITLE
fix: Add CC on inline videos 

### DIFF
--- a/Source/View Generators/WKWebViewGenerator.swift
+++ b/Source/View Generators/WKWebViewGenerator.swift
@@ -31,7 +31,7 @@ class WKWebViewGenerator {
 
     private static func getWebViewURL(from input: String) -> URL? {
         if let youTubeID = input.getSubstring(inBetween: RichTextViewConstants.youtubeStartTag, and: RichTextViewConstants.videoEndTag) {
-            return URL(string: "https://www.youtube.com/embed/" + youTubeID + "?playsinline=1")
+            return URL(string: "https://www.youtube.com/embed/" + youTubeID + "?playsinline=1&cc_load_policy=1")
         } else if let vimeoID = input.getSubstring(inBetween: RichTextViewConstants.vimeoStartTag, and: RichTextViewConstants.videoEndTag) {
             return URL(string: "https://player.vimeo.com/video/" + vimeoID + "?title=0&byline=0&portrait=0")
         }

--- a/UnitTests/View Generators/WKWebViewGeneratorSpec.swift
+++ b/UnitTests/View Generators/WKWebViewGeneratorSpec.swift
@@ -18,7 +18,7 @@ class WKWebViewGeneratorSpec: QuickSpec {
                 it("properly generates a YouTube WebView") {
                     let webview = WKWebViewGenerator.getWebView(from: "youtube[1234]")
                     expect(webview?.configuration.allowsInlineMediaPlayback).to(beTrue())
-                    expect(webview?.url?.absoluteString).to(equal("https://www.youtube.com/embed/1234?playsinline=1"))
+                    expect(webview?.url?.absoluteString).to(equal("https://www.youtube.com/embed/1234?playsinline=1&cc_load_policy=1"))
                 }
                 it("properly generates a Vimeo WebView") {
                     let webview = WKWebViewGenerator.getWebView(from: "vimeo[1234]")


### PR DESCRIPTION
## Description
Added CC to show when playing inline videos from youtube. 


## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Run `pod install`
- Test `RichTextView` to ensure that it passes (unit and UI tests)
- Navigate to the `Example` project in the root `Example` folder and run the app
- Ensure that everything in the `Example` app looks visually correct


### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->



### Comments
<!-- Any other comments you want to include for reviewers. -->


