### PR TITLE
Docs📄: add swift lang reference for <code> block

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -26,7 +26,7 @@ iOS Text View (`UIView`) that Properly Displays LaTeX, HTML, Markdown, and YouTu
 
 Simply add the following to your Podfile:
 
-```
+```sh
 pod 'RichTextView'
 ```
 
@@ -36,7 +36,7 @@ And run `pod install` in your repo.
 
 Simply add the following to your Cartfile:
 
-```
+```sh
 github "tophat/RichTextView"
 ```
 
@@ -46,12 +46,12 @@ And run `carthage update --platform iOS` in your repo.
 
 You can instantiate a `RichTextView` by importing the project first:
 
-```
+```swift
 import RichTextView
 ```
 To init a `RichTextView`:
 
-```
+```swift
 let richTextView = RichTextView(
     input: "Test",
     latexParser: LatexParser(),
@@ -69,7 +69,7 @@ let richTextView = RichTextView(
 
 You can also update an existing `RichTextView` as follows:
 
-```
+```swift
 richTextView.update(
     input: "Test",
     latexParser: LatexParser(),


### PR DESCRIPTION
Add a swift language reference for Markdown Element `<code/>`

## Description
<!-- Add a bulleted list of items changed or added -->
- Edited Readme.me

## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Run `pod install`
- Test `RichTextView` to ensure that it passes (unit and UI tests)
- Navigate to the `Example` project in the root `Example` folder and run the app
- Ensure that everything in the `Example` app looks visually correct


### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->
This is a PR related to changes in documentation. So, I have ignored it.


### Comments
<!-- Any other comments you want to include for reviewers. -->


