### PR TITLE
fix: Use better iosMath versioning in our Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     dependencies: [
         .package(name: "Down", url: "https://github.com/johnxnguyen/Down", .upToNextMajor(from: "0.11.0")),
         .package(name: "SnapKit", url: "https://github.com/SnapKit/SnapKit", .upToNextMajor(from: "5.0.1")),
-        .package(name: "iosMath", url: "https://github.com/tophatmonocle/iosMath", .branch("master")),
+        .package(name: "iosMath", url: "https://github.com/tophatmonocle/iosMath", .upToNextMajor(from: "1.1.1")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Description
We now use better versioning of our iosMath fork in our Package.swift


